### PR TITLE
Fix for Postgres

### DIFF
--- a/edit/achievement.php
+++ b/edit/achievement.php
@@ -407,7 +407,7 @@ function get_rubric_base($rubric, $id) {
 			INNER JOIN {artefact_rubric_year} y ON r.id = y.rubric
 			WHERE r.id = ?
 			AND s.id = (SELECT MAX(skill) FROM {artefact_rubric_score} WHERE id = ?)
-			AND y.id = (SELECT MAX(year) FROM `artefact_rubric_score` WHERE id = ?)"
+			AND y.id = (SELECT MAX(year) FROM {artefact_rubric_score} WHERE id = ?)"
 			, array($rubric, $id, $id)) ;
 }
 

--- a/edit/radarchart.php
+++ b/edit/radarchart.php
@@ -138,7 +138,7 @@ $myPicture->stroke();
 
 //評価基準
 function get_standard_maxpoint($id) {
-	$result = get_records_sql_array("SELECT MAX(point) point FROM {artefact_rubric_standard} WHERE rubric = ? ORDER BY id", array($id)) ;
+	$result = get_records_sql_array("SELECT MAX(point) point FROM {artefact_rubric_standard} WHERE rubric = ?", array($id)) ;
 	return $result[0]->point;
 }
 

--- a/lib.php
+++ b/lib.php
@@ -164,6 +164,7 @@ class ArtefactTyperubric extends ArtefactType {
     			$fordb->{'standard'} = $cell->standard;
     			$fordb->{'year'} = $year->id;
     			$fordb->{'comment'} = '';
+    			$fordb->{'default_flg'} = 0;
     			insert_record('artefact_rubric_score', $fordb);
     		}
     	}
@@ -382,7 +383,13 @@ class ArtefactTyperubric extends ArtefactType {
     // --> SCSK ADD 2014.12.22
     public static function get_statistics_data($rubric, $year) {
 
-    	$records = get_records_sql_array("SELECT sc.usr, concat(u.firstname, ' ', u.lastname) AS name,
+      if ( is_mysql() ) {
+	$full_name = "concat(u.firstname, ' ', u.lastname)";
+      } else {
+	$full_name = "u.firstname||' '||u.lastname";
+      }
+
+    	$records = get_records_sql_array("SELECT sc.usr, $full_name AS name,
     			st.id AS standard, CASE WHEN sc.default_flg = 1 THEN st.point ELSE 0 END AS point,
     			ye.id AS year, ye.title AS ytitle, sk.id AS skill, sk.title AS stitle, sc.default_flg,
     			CASE WHEN sc.default_flg = 1 THEN ce.label ELSE '-' END AS label, st.bgcolor
@@ -513,14 +520,30 @@ class ArtefactTyperubric extends ArtefactType {
 
     public static function get_score_musr_mtime($score) {
 
-    	return get_record_sql("SELECT CONCAT(u.firstname, ' ', u.lastname) AS name, DATE_FORMAT(mtime, '%Y/%m/%d %k:%i') AS date FROM usr u
+      if ( is_mysql() ) {
+	$full_name = "concat(u.firstname, ' ', u.lastname)";
+	$date_format = "DATE_FORMAT(mtime, '%Y/%m/%d %k:%i')";
+      } else {
+	$full_name = "u.firstname||' '||u.lastname";
+	$date_format = "to_char(mtime,'YYYY/MM/DD HH:MI')";
+      }
+
+    	return get_record_sql("SELECT $full_name AS name, $date_format AS date FROM usr u
 						INNER JOIN artefact_rubric_score s ON s.musr = u.id
 						WHERE s.id = ?", array($score));
     }
 
     public static function get_evidence_musr_mtime($score) {
 
-    	return get_record_sql("SELECT CONCAT(u.firstname, ' ', u.lastname) AS name, DATE_FORMAT(e.mtime, '%Y/%m/%d %k:%i') AS date FROM usr u
+      if ( is_mysql() ) {
+	$full_name = "concat(u.firstname, ' ', u.lastname)";
+	$date_format = "DATE_FORMAT(e.mtime, '%Y/%m/%d %k:%i')";
+      } else {
+	$full_name = "u.firstname||' '||u.lastname";
+	$date_format = "to_char(e.mtime,'YYYY/MM/DD HH:MI')";
+      }
+
+    	return get_record_sql("SELECT $full_name AS name, $date_format AS date FROM usr u
 						INNER JOIN artefact_rubric_evidence e ON e.musr = u.id
 						WHERE e.score = ? ORDER BY e.mtime DESC LIMIT 1", array($score));
     }


### PR DESCRIPTION
MySQLのconcat()とdate_format()がPostgreSQLにないので、||演算子とto_char()で代用しました。is_mysql()でDB判別してるので、MySQLでもそのまま使えます。

date_fomat()をto_char()で代用している部分は、厳密には同じ結果ではないです。to_char()で、数字にゼロリーディングを付けない方法がわかりませんでしたので、そのままにしています。

ex) date_format() → 2015/3/8 に対して to_char() → 2015/03/08 となる。

edit/achievement.php と edit/radarchart.php は、ケアレスミスの修正です。MySQLだとこのままでも動きますが、PostgreSQLだとエラーになるので気づいたところです。
